### PR TITLE
feat: interactive contact_request + contacts vcard/origin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "WhatsappApiClient"
-version = "0.15.1"
+version = "0.16.0"
 description = "Whatsapp API client"
 authors = ["a5r0n <a5r0n@users.noreply.github.com>"]
 packages = [{ include = "whatsapp" }]
@@ -21,7 +21,7 @@ pytest-dotenv = "^0.5.2"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.15.1"
+version = "0.16.0"
 tag_format = "v$version"
 version_files = [
     "pyproject.toml:version",

--- a/tests/test_incoming.py
+++ b/tests/test_incoming.py
@@ -284,3 +284,33 @@ def test_message_update_preserves_legacy_system_message_parsing():
     assert message.system.type == "user_changed_number"
     assert message.sender_identifier == "16505551234"
     assert message.identifier_change is None
+
+
+def test_incoming_contacts_message_parses_vcard_and_origin():
+    from whatsapp._models.contacts import Contact
+
+    contact = Contact.model_validate(
+        {
+            "vcard": "BEGIN:VCARD\nVERSION:3.0\nFN:Alice\nEND:VCARD",
+            "origin": "contact_request",
+            "phones": [
+                {
+                    "type": "CELL",
+                    "phone": "+15551234567",
+                    "wa_id": "15551234567",
+                }
+            ],
+        }
+    )
+
+    assert contact.vcard.startswith("BEGIN:VCARD")
+    assert contact.origin == "contact_request"
+    assert contact.phones[0].wa_id == "15551234567"
+
+
+def test_incoming_contacts_message_accepts_other_origin():
+    from whatsapp._models.contacts import Contact
+
+    contact = Contact.model_validate({"origin": "other", "phones": []})
+
+    assert contact.origin == "other"

--- a/tests/test_incoming.py
+++ b/tests/test_incoming.py
@@ -311,6 +311,6 @@ def test_incoming_contacts_message_parses_vcard_and_origin():
 def test_incoming_contacts_message_accepts_other_origin():
     from whatsapp._models.contacts import Contact
 
-    contact = Contact.model_validate({"origin": "other", "phones": []})
+    contact = Contact.model_validate({"origin": "other"})
 
     assert contact.origin == "other"

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -156,3 +156,28 @@ async def test_client_send_media_supports_parent_business_scoped_user_ids(
     assert message.parent_user_id == "US.ENT.123456789"
     assert message.to is None
     assert captured["data"].recipient_identifier == "US.ENT.123456789"
+
+
+def test_interactive_contact_request_serializes_to_meta_shape():
+    message = messages.Message(
+        user_id="US.123456789",
+        type=messages.MessageType.INTERACTIVE,
+        interactive=messages.interactive.InteractiveContactRequest(
+            body=messages.interactive.Text(text="Share your number with us"),
+            action=messages.interactive.ContactRequestAction(),
+        ),
+    )
+
+    payload = message.model_dump(exclude_none=True)
+
+    assert payload["interactive"]["type"] == "contact_request"
+    assert payload["interactive"]["body"] == {"text": "Share your number with us"}
+    assert payload["interactive"]["action"] == {"name": "request_contact_info"}
+    assert "header" not in payload["interactive"]
+    assert "footer" not in payload["interactive"]
+    assert payload["user_id"] == "US.123456789"
+
+
+def test_interactive_contact_request_action_name_is_fixed():
+    with pytest.raises(ValidationError):
+        messages.interactive.ContactRequestAction(name="something_else")

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -181,3 +181,35 @@ def test_interactive_contact_request_serializes_to_meta_shape():
 def test_interactive_contact_request_action_name_is_fixed():
     with pytest.raises(ValidationError):
         messages.interactive.ContactRequestAction(name="something_else")
+
+
+def test_message_validates_contact_request_via_interactive_union():
+    payload = {
+        "user_id": "US.123456789",
+        "type": "interactive",
+        "interactive": {
+            "type": "contact_request",
+            "body": {"text": "Share your number with us"},
+            "action": {"name": "request_contact_info"},
+        },
+    }
+
+    message = messages.Message.model_validate(payload)
+
+    assert isinstance(
+        message.interactive, messages.interactive.InteractiveContactRequest
+    )
+
+
+def test_contact_request_action_resolves_to_correct_type_in_union():
+    from whatsapp._models import interactive
+
+    parsed = interactive.Interactive.model_validate(
+        {
+            "type": "contact_request",
+            "body": {"text": "hi"},
+            "action": {"name": "request_contact_info"},
+        }
+    )
+
+    assert isinstance(parsed.action, interactive.ContactRequestAction)

--- a/whatsapp/__init__.py
+++ b/whatsapp/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.15.1"
+__version__ = "0.16.0"
 
 from .client import Client as WhatsAppClient
 from .config import WhatsAppConfig

--- a/whatsapp/_models/contacts.py
+++ b/whatsapp/_models/contacts.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Literal, Optional
 from pydantic import RootModel, model_validator, BaseModel, Field
 
 
@@ -70,6 +70,21 @@ class Contact(BaseModel):
     phones: Optional[List[Phone]] = Field(None, description="Contact phone number(s)")
     urls: Optional[List[Url]] = Field(None, description="Contact URL(s)")
     contact_image: Optional[str] = Field(None, description="Contact image")
+    vcard: Optional[str] = Field(
+        None,
+        description=(
+            "Virtual contact card. Present when the user shared a contact directly"
+            " (origin=other); omitted when origin=contact_request."
+        ),
+    )
+    origin: Optional[Literal["contact_request", "other"]] = Field(
+        None,
+        description=(
+            "How the contact information was shared."
+            " contact_request = user tapped a REQUEST_CONTACT_INFO button."
+            " other = user shared a contact directly in the chat."
+        ),
+    )
 
     # TODO: #69 move to base model
     @model_validator(mode="before")

--- a/whatsapp/_models/interactive.py
+++ b/whatsapp/_models/interactive.py
@@ -28,6 +28,7 @@ class InteractiveTypes(str, Enum):
     PRODUCT_LIST = "product_list"
     FLOW = "flow"
     CATALOG_MESSAGE = "catalog_message"
+    CONTACT_REQUEST = "contact_request"
 
 
 class HeaderTypes(str, Enum):
@@ -199,6 +200,10 @@ class UrlAction(Action):
         return cls(parameters=UrlParameters(url=url, display_text=display_text))
 
 
+class ContactRequestAction(Action):
+    name: Literal["request_contact_info"] = "request_contact_info"
+
+
 class Interactive(BaseModel):
     type: InteractiveTypes
     body: Text
@@ -212,6 +217,7 @@ class Interactive(BaseModel):
         ProductAction,
         CatalogMessageAction,
         UrlAction,
+        ContactRequestAction,
     ]
     model_config = ConfigDict(use_enum_values=True)
 
@@ -261,3 +267,10 @@ class InteractiveCatalogMessage(Interactive):
 class InteractiveUrl(Interactive):
     type: InteractiveTypes = InteractiveTypes.URL
     action: UrlAction
+
+
+class InteractiveContactRequest(Interactive):
+    type: InteractiveTypes = InteractiveTypes.CONTACT_REQUEST
+    header: Literal[None] = None
+    footer: Literal[None] = None
+    action: ContactRequestAction

--- a/whatsapp/_models/interactive.py
+++ b/whatsapp/_models/interactive.py
@@ -215,9 +215,9 @@ class Interactive(BaseModel):
         FlowAction,
         ProductListAction,
         ProductAction,
+        ContactRequestAction,
         CatalogMessageAction,
         UrlAction,
-        ContactRequestAction,
     ]
     model_config = ConfigDict(use_enum_values=True)
 

--- a/whatsapp/messages.py
+++ b/whatsapp/messages.py
@@ -11,6 +11,7 @@ from whatsapp._models.interactive import (
     InteractiveProductList,
     InteractiveCatalogMessage,
     InteractiveUrl,
+    InteractiveContactRequest,
 )
 from whatsapp._models.reaction import Reaction
 from whatsapp._models.template import (
@@ -88,6 +89,7 @@ class Message(BaseModel):
             InteractiveFlow,
             InteractiveProduct,
             InteractiveProductList,
+            InteractiveContactRequest,
             InteractiveCatalogMessage,
             InteractiveUrl,
         ]


### PR DESCRIPTION
## Summary
- Add `InteractiveContactRequest` outbound interactive type with `ContactRequestAction` (name="request_contact_info")
- Add `InteractiveTypes.CONTACT_REQUEST` enum value and wire into `Interactive.action` and `Message.interactive` unions
- Reorder both Unions to place the new members ahead of permissively-typed members (`CatalogMessageAction` / `InteractiveCatalogMessage`) to avoid pydantic v2 left-to-right resolution swallowing contact_request payloads
- Model `vcard` and `origin` fields on incoming `Contact` from the contacts webhook

## Test plan
- [ ] `uv run pytest tests/test_messages.py tests/test_incoming.py`