### PR TITLE
fix: emit interactive.type=request_contact_info to match Meta API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "WhatsappApiClient"
-version = "0.16.0"
+version = "0.16.1"
 description = "Whatsapp API client"
 authors = ["a5r0n <a5r0n@users.noreply.github.com>"]
 packages = [{ include = "whatsapp" }]
@@ -21,7 +21,7 @@ pytest-dotenv = "^0.5.2"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.16.0"
+version = "0.16.1"
 tag_format = "v$version"
 version_files = [
     "pyproject.toml:version",

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -170,7 +170,7 @@ def test_interactive_contact_request_serializes_to_meta_shape():
 
     payload = message.model_dump(exclude_none=True)
 
-    assert payload["interactive"]["type"] == "contact_request"
+    assert payload["interactive"]["type"] == "request_contact_info"
     assert payload["interactive"]["body"] == {"text": "Share your number with us"}
     assert payload["interactive"]["action"] == {"name": "request_contact_info"}
     assert "header" not in payload["interactive"]
@@ -188,7 +188,7 @@ def test_message_validates_contact_request_via_interactive_union():
         "user_id": "US.123456789",
         "type": "interactive",
         "interactive": {
-            "type": "contact_request",
+            "type": "request_contact_info",
             "body": {"text": "Share your number with us"},
             "action": {"name": "request_contact_info"},
         },
@@ -206,7 +206,7 @@ def test_contact_request_action_resolves_to_correct_type_in_union():
 
     parsed = interactive.Interactive.model_validate(
         {
-            "type": "contact_request",
+            "type": "request_contact_info",
             "body": {"text": "hi"},
             "action": {"name": "request_contact_info"},
         }

--- a/whatsapp/__init__.py
+++ b/whatsapp/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.16.0"
+__version__ = "0.16.1"
 
 from .client import Client as WhatsAppClient
 from .config import WhatsAppConfig

--- a/whatsapp/_models/interactive.py
+++ b/whatsapp/_models/interactive.py
@@ -28,7 +28,7 @@ class InteractiveTypes(str, Enum):
     PRODUCT_LIST = "product_list"
     FLOW = "flow"
     CATALOG_MESSAGE = "catalog_message"
-    CONTACT_REQUEST = "contact_request"
+    CONTACT_REQUEST = "request_contact_info"
 
 
 class HeaderTypes(str, Enum):


### PR DESCRIPTION
## Summary
Live test on staging revealed Meta's Cloud API rejects `interactive.type: "contact_request"` with a JSON schema enum violation (code 100). The valid enum value is `request_contact_info`.

## Fix
- `InteractiveTypes.CONTACT_REQUEST` enum value: `"contact_request"` → `"request_contact_info"`
- Update tests to assert the new wire value
- Version bump 0.16.0 → 0.16.1

## Meta error captured
\`\`\`
"interactive.type"... expected: [..., request_contact_info, ...] but got "contact_request"
fbtrace_id: Ac7FHQgSE32Hnjr6jY_z448
\`\`\`

## Test plan
- [x] uv run pytest tests/test_messages.py tests/test_incoming.py → 24/24 passed