### PR TITLE
fix(responses): accept numeric media file size

### DIFF
--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -50,3 +50,49 @@ def test_messages_response_supports_business_scoped_user_ids():
     assert response.contact_models[0].parent_user_id == "US.ENT.123456789"
     assert response.contact_models[0].username == "scoped_user"
     assert response.contact_models[0].identifier == "US.123456789"
+
+
+def test_media_response_accepts_graph_api_integer_file_size():
+    response = responses.MediaResponse.model_validate(
+        {
+            "id": "974888005314047",
+            "messaging_product": "whatsapp",
+            "url": "https://lookaside.fbsbx.com/whatsapp_business/attachments/974888005314047",
+            "mime_type": "image/jpeg",
+            "sha256": "088bae189dedac6c9c91286c31eb5df50a08da452f246a75802ba1ce6252d6d7",
+            "file_size": 85175,
+        }
+    )
+
+    assert response.file_size == 85175
+
+
+def test_media_response_accepts_legacy_string_file_size():
+    response = responses.MediaResponse.model_validate(
+        {
+            "id": "974888005314047",
+            "messaging_product": "whatsapp",
+            "url": "https://lookaside.fbsbx.com/whatsapp_business/attachments/974888005314047",
+            "mime_type": "image/jpeg",
+            "sha256": "088bae189dedac6c9c91286c31eb5df50a08da452f246a75802ba1ce6252d6d7",
+            "file_size": "85175",
+        }
+    )
+
+    assert response.file_size == 85175
+
+
+def test_api_response_detects_media_response_with_integer_file_size():
+    response = responses.ApiResponse.model_validate(
+        {
+            "id": "974888005314047",
+            "messaging_product": "whatsapp",
+            "url": "https://lookaside.fbsbx.com/whatsapp_business/attachments/974888005314047",
+            "mime_type": "image/jpeg",
+            "sha256": "088bae189dedac6c9c91286c31eb5df50a08da452f246a75802ba1ce6252d6d7",
+            "file_size": 85175,
+        }
+    ).root
+
+    assert isinstance(response, responses.MediaResponse)
+    assert response.file_size == 85175

--- a/whatsapp/responses.py
+++ b/whatsapp/responses.py
@@ -165,7 +165,7 @@ class MediaResponse(Response):
     url: str
     mime_type: str
     sha256: str
-    file_size: str
+    file_size: int
     id: str
 
 


### PR DESCRIPTION
## Summary
- Change MediaResponse.file_size to an integer so Meta Graph API media responses with numeric file_size parse under Pydantic v2
- Keep compatibility for legacy numeric strings via Pydantic coercion
- Add regression coverage for direct MediaResponse parsing and ApiResponse union detection

## Similar-error audit
- Reviewed response models for Pydantic v2 numeric/string coercion issues
- This bug is isolated to MediaResponse.file_size: Meta returns it as a byte count number, while the model declared it as str
- Other response fields with str types are identifiers/text fields in current payloads, not documented numeric counters in the same Graph media response path

## Test plan
- [x] uv run --active pytest tests/test_responses.py -q
- [x] uv run --active pytest tests/test_responses.py tests/test_incoming.py tests/test_messages.py tests/test_client.py tests/test_config.py -q

Note: full pytest currently has unrelated existing network/config failures in tests/test_whatsapp.py (httpbin/fixture/env issues), so I verified the non-live/unit subset relevant to the change.