### PR TITLE
feat(incoming): parse Click-to-WhatsApp referral object on inbound messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "WhatsappApiClient"
-version = "0.16.2"
+version = "0.17.0"
 description = "Whatsapp API client"
 authors = ["a5r0n <a5r0n@users.noreply.github.com>"]
 packages = [{ include = "whatsapp" }]
@@ -21,7 +21,7 @@ pytest-dotenv = "^0.5.2"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.16.2"
+version = "0.17.0"
 tag_format = "v$version"
 version_files = [
     "pyproject.toml:version",

--- a/tests/test_incoming.py
+++ b/tests/test_incoming.py
@@ -314,3 +314,97 @@ def test_incoming_contacts_message_accepts_other_origin():
     contact = Contact.model_validate({"origin": "other"})
 
     assert contact.origin == "other"
+
+
+def test_message_update_parses_click_to_whatsapp_referral():
+    update = MessageUpdate.model_validate(
+        {
+            "messages": [
+                {
+                    "from": "16505551234",
+                    "id": "wamid.referral",
+                    "timestamp": "1700000000",
+                    "type": "text",
+                    "text": {"body": "Interested!"},
+                    "referral": {
+                        "source_url": "https://fb.me/AD_URL",
+                        "source_id": "120210000000000000",
+                        "source_type": "ad",
+                        "headline": "Our Sale",
+                        "body": "50% off",
+                        "media_type": "image",
+                        "image_url": "https://example.com/i.jpg",
+                        "thumbnail_url": "https://example.com/t.jpg",
+                        "ctwa_clid": "AfezABC123xyz",
+                    },
+                }
+            ]
+        }
+    )
+
+    message = update.messages[0]
+
+    assert message.referral is not None
+    assert message.referral.source_url == "https://fb.me/AD_URL"
+    assert message.referral.source_id == "120210000000000000"
+    assert message.referral.source_type == "ad"
+    assert message.referral.headline == "Our Sale"
+    assert message.referral.body == "50% off"
+    assert message.referral.media_type == "image"
+    assert message.referral.image_url == "https://example.com/i.jpg"
+    assert message.referral.video_url is None
+    assert message.referral.thumbnail_url == "https://example.com/t.jpg"
+    assert message.referral.ctwa_clid == "AfezABC123xyz"
+
+
+def test_message_update_without_referral_leaves_referral_none():
+    update = MessageUpdate.model_validate(
+        {
+            "messages": [
+                {
+                    "from": "16505551234",
+                    "id": "wamid.no-referral",
+                    "timestamp": "1700000001",
+                    "type": "text",
+                    "text": {"body": "hello"},
+                }
+            ]
+        }
+    )
+
+    assert update.messages[0].referral is None
+
+
+def test_message_update_parses_partial_referral():
+    update = MessageUpdate.model_validate(
+        {
+            "messages": [
+                {
+                    "from": "16505551234",
+                    "id": "wamid.partial-referral",
+                    "timestamp": "1700000002",
+                    "type": "text",
+                    "text": {"body": "Interested!"},
+                    "referral": {
+                        "source_type": "post",
+                        "source_id": "120210000000000001",
+                        "ctwa_clid": "AfezPartial456",
+                    },
+                }
+            ]
+        }
+    )
+
+    referral = update.messages[0].referral
+
+    assert referral is not None
+    assert referral.source_type == "post"
+    assert referral.source_id == "120210000000000001"
+    assert referral.ctwa_clid == "AfezPartial456"
+    assert referral.source_url is None
+    assert referral.headline is None
+    assert referral.body is None
+    assert referral.media_type is None
+    assert referral.image_url is None
+    assert referral.video_url is None
+    assert referral.thumbnail_url is None

--- a/whatsapp/__init__.py
+++ b/whatsapp/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.16.2"
+__version__ = "0.17.0"
 
 from .client import Client as WhatsAppClient
 from .config import WhatsAppConfig

--- a/whatsapp/incoming.py
+++ b/whatsapp/incoming.py
@@ -229,6 +229,19 @@ class Context(BaseModel):
     mentions: Optional[List[str]] = None
 
 
+class Referral(BaseModel):
+    source_type: Optional[str] = None
+    source_id: Optional[str] = None
+    source_url: Optional[str] = None
+    headline: Optional[str] = None
+    body: Optional[str] = None
+    media_type: Optional[str] = None
+    image_url: Optional[str] = None
+    video_url: Optional[str] = None
+    thumbnail_url: Optional[str] = None
+    ctwa_clid: Optional[str] = None
+
+
 class Button(BaseModel):
     text: str
     payload: Optional[str] = None
@@ -289,6 +302,7 @@ class Message(BaseModel):
     type: IncomingMessageType
     group_id: Optional[str] = None
     context: Optional[Context] = None
+    referral: Optional[Referral] = None
 
     text: Optional[Text] = None
     image: Optional[Media] = None


### PR DESCRIPTION
## Summary

Adds support for the WhatsApp Click-to-WhatsApp (CTWA) ad **referral** object on inbound messages.

When a user starts a conversation by clicking a Click-to-WhatsApp ad (or a FB/IG post with a WhatsApp button), the inbound message webhook carries a `referral` object as a **sibling** of the message fields (`from`, `id`, `timestamp`, `type`, `text`) — not nested in `context`. Previously the library dropped it entirely (`Message` uses `extra="ignore"`).

## Changes

- New `Referral` pydantic model in `whatsapp/incoming.py` with all fields optional (`source_type`, `source_id`, `source_url`, `headline`, `body`, `media_type`, `image_url`, `video_url`, `thumbnail_url`, `ctwa_clid`). Every field is optional because the object is optional and Meta lets senders strip individual fields.
- New `referral: Optional[Referral] = None` field on `Message` (inherited automatically by `PrivateMessage`/`GroupMessage`).
- No change to `model_config`; a declared field is parsed regardless of `extra`.

## Tests

Added three tests in `tests/test_incoming.py`:
- Full referral payload → every field maps correctly.
- No referral → `message.referral is None`.
- Partial referral (`source_type` + `source_id` + `ctwa_clid` only) → present fields set, missing ones `None`.

`uv run pytest tests/test_incoming.py` → 14 passed. Full-suite delta: +3 passing, no new failures (pre-existing `test_whatsapp.py` upload/network failures are unrelated to this change).

## Version

Backward-compatible feature add → minor bump `0.16.2` → `0.17.0` (both `pyproject.toml` and `whatsapp/__init__.py`).